### PR TITLE
modified calculate_homology to work with dist

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,8 @@ Authors@R: c(
     person("Raoul", "Wadhwa", email = "raoulwadhwa@gmail.com", role = c("aut", "cre")),
     person("Andrew", "Dhawan", role = "aut"),
     person("Drew", "Williamson", role = "aut"),
-    person("Jacob", "Scott", role = "aut"))
+    person("Jacob", "Scott", role = "aut"),
+    person("Shota", "Ochi", role = "ctb"))
 Description: A comprehensive toolset for any
     useR conducting topological data analysis, specifically via the
     calculation of persistent homology in a Vietoris-Rips complex.

--- a/R/calculate.R
+++ b/R/calculate.R
@@ -31,6 +31,11 @@
 #' pers.hom <- calculate_homology(pt.cloud)
 calculate_homology <- function(mat, dim = 1, threshold = -1, format = "cloud",
                                standardize = FALSE) {
+  # convert mat to matirx if class of mat is dist
+  if (any(class(mat) == "dist")) {
+    mat <- as.matrix(mat)
+  }
+  
   # make sure matrix has at least 2 columns and at least 2 rows
   if (nrow(mat) < 2 | ncol(mat) < 2) {
     stop("Point cloud must have at least 2 points and at least 2 dimensions.")

--- a/R/calculate.R
+++ b/R/calculate.R
@@ -31,10 +31,8 @@
 #' pers.hom <- calculate_homology(pt.cloud)
 calculate_homology <- function(mat, dim = 1, threshold = -1, format = "cloud",
                                standardize = FALSE) {
-  # convert mat to matirx if class of mat is dist
-  if (any(class(mat) == "dist")) {
-    mat <- as.matrix(mat)
-  }
+  # coerce mat into matirx to work with class object such as dist class object
+  mat <- as.matrix(mat)
   
   # make sure matrix has at least 2 columns and at least 2 rows
   if (nrow(mat) < 2 | ncol(mat) < 2) {

--- a/R/calculate.R
+++ b/R/calculate.R
@@ -31,7 +31,7 @@
 #' pers.hom <- calculate_homology(pt.cloud)
 calculate_homology <- function(mat, dim = 1, threshold = -1, format = "cloud",
                                standardize = FALSE) {
-  # coerce mat into matirx to work with class object such as dist class object
+  # coerce mat into matrix to work with class object such as dist class object
   mat <- as.matrix(mat)
   
   # make sure matrix has at least 2 columns and at least 2 rows


### PR DESCRIPTION
I modified calculate_homology function to work with dist class object.
Now, mat will be converted to matrix when mat is dist class object.
The point of modification is shown below.
```
  # convert mat to matirx if class of mat is dist
  if (any(class(mat) == "dist")) {
    mat <- as.matrix(mat)
  }
```